### PR TITLE
Add missing decorators

### DIFF
--- a/monty.py
+++ b/monty.py
@@ -824,8 +824,8 @@ def modmli(n) :
         str+="\tc[{}]+=s;\n".format(trin)
     else :
         str+="\tspint t[{}];\n".format(N)
-        str+="\tmodint(b,t);\n"
-        str+="\tmodmul(a,t,c);\n"
+        str+="\tmodint{}(b,t);\n".format(DECOR)
+        str+="\tmodmul{}(a,t,c);\n".format(DECOR)
     str+="}\n"
     return str
 
@@ -1392,10 +1392,10 @@ def mod2r() :
     str+="void mod2r{}(unsigned int r,spint *a) {{\n".format(DECOR)
     str+="\tunsigned int n=r/{}u;\n".format(base)
     str+="\tunsigned int m=r%{}u;\n".format(base)
-    str+="\tmodzer(a);\n"
+    str+="\tmodzer{}(a);\n".format(DECOR)
     str+="\tif (r>={}*8) return;\n".format(Nbytes)
     str+="\ta[n]=1; a[n]<<=m;\n"
-    str+="nres(a,a);\n}\n"
+    str+="nres{}(a,a);\n}}\n".format(DECOR)
     return str
 
 #export to byte array

--- a/pseudo.py
+++ b/pseudo.py
@@ -971,7 +971,7 @@ def mod2r() :
     str+="void mod2r{}(unsigned int r,spint *a) {{\n".format(DECOR)
     str+="\tunsigned int n=r/{}u;\n".format(base)
     str+="\tunsigned int m=r%{}u;\n".format(base)
-    str+="\tmodzer(a);\n"
+    str+="\tmodzer{}(a);\n".format(DECOR)
     str+="\tif (r>={}*8) return;\n".format(Nbytes)
     str+="\ta[n]=1; a[n]<<=m;\n}\n"
     return str
@@ -1004,7 +1004,7 @@ def modimp() :
     str+="\tfor (i=0;i<{};i++) {{\n".format(Nbytes)
     str+="\t\tmodshl{}(8,a);\n".format(DECOR)
     str+="\t\ta[0]+=(spint)(unsigned char)b[i];\n\t}\n"
-    str+="\tres=modfsb(a);\n"
+    str+="\tres=modfsb{}(a);\n".format(DECOR)
     str+="\tnres{}(a,a);\n".format(DECOR)
     str+="\treturn res;\n"
     str+="}\n"


### PR DESCRIPTION
Thank you for this project. The following pull request fixes a small issue when `decoration` is set to `True` at the beginning of the script: there are some compilation errors for code generated with either `pseudo.py` or `monty.py`, due to the fact that the script generates some function calls without the decorator.

Note that I have only tested the C code generators; it is possible a similar issue exists in the Rust code generators, but I haven't verified this.